### PR TITLE
Add a link to the F29 beta iso

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -6,7 +6,7 @@
 <h1>Download a Silverblue image</h1>
 
 <p>Silverblue images for Fedora 28 are provided by the Fedora Project.</p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/28/AtomicWorkstation/x86_64/iso/Fedora-AtomicWorkstation-ostree-x86_64-28-1.1.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 1.9GB Silverblue image</a></p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/28/AtomicWorkstation/x86_64/iso/Fedora-AtomicWorkstation-ostree-x86_64-28-1.1.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 1.9GB Silverblue image (Fedora 28)</a></p>
 
 <p>Fedora provides the Media Writer as a convenient way to create bootable USB drives.</p>
 <p>You will need
@@ -23,6 +23,11 @@ and follow the prompts to write the image to the USB Drive.</p>
 <p>You may then install Silverblue by booting from your USB Drive. <b>Note:</b> it is
 advisable to keep the default partitioning setup that the Installer suggests,
 since rpm-ostree expects this setup.</p>
+
+<h1>Try the latest</h1>
+
+<p>Help us make Silverblue better by testing the <b>beta</b> release of Silverblue for Fedora 29.</p>
+<p><a class="button" href='https://kojipkgs.fedoraproject.org/compose/29/Fedora-29-20180912.0/compose/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-29_Beta-1.1.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 2.0GB Silverblue image (Fedora 29 <b>beta</b>)</a></p>
 
 <h1>Get Fedora Media Writer</h1>
 


### PR DESCRIPTION
We still have the stable F28 release on the top of the page,
but add the F29 beta as a separate download for the adventurous.