### PR TITLE
Archive the "Flatpak 1.0" post

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -3,16 +3,58 @@
 
 {{define "body"}}
 <article>
-  <h2>Congratulations, Flatpak!</h2>
-    <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2018-08-20">August 20, 2018</time></p>
+  <h2>A look around Team Silverblue</h2>
+    <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2018-09-13">September 13, 2018</time></p>
 
-    <p>Flatpak has reached a major milestone today, with its 1.0 release.</p>
+    <p>A while ago ago, we introduced Team Silverblue as a new initiative in Fedora.
+    Lets take a deeper look and see what the project is about and how it works.</p>
 
-    <a href="https://www.flatpak.org/press/2018-08-20-flatpak-1.0/"><image src="https://www.flatpak.org/img/delivery_truck.png"/></a>
+    <img class="blog-image" alt="Silverblue logo" src="/public/silverblue-logo.svg">
 
-    <p>We in Team Silverblue are all excited and happy to use <a href="https://www.flatpak.org/press/2018-08-20-flatpak-1.0/">Flatpak 1.0</a> as the solid
-    foundation for application deployment and execution in Fedora Silverblue.</p>
+    <h3>Goals and Deliverables</h3>
 
-    <p>Keep it coming! ️💓📦💓📦</p>
+    <p>Before we chose the name Team Silverblue, the team was the Fedora Atomic Workstation SIG,
+    and the <i>Atomic Workstation</i> is what we are producing, now under its new name,
+    <em>Silverblue</em>. At its core, it is a variant of the Fedora Workstation which uses
+    rpm-ostree to provide an immutable OS image with reliable updates and easy rollbacks.</p>
+
+    <p>The concrete goals of the Team Silverblue project are to provide excellent support for
+    container-based workflows and make Silverblue the preferred variant of Fedora Workstation.
+    We want to reach these goals by the time Fedora 30 is released.</p>
+
+    <p>To get there, we need to close a number of remaining gaps in the Flatpak and OSTree support
+    in GNOME Software, and improve the support for contrainer-based workflows in the desktop.</p>
+    <ul>
+      <li>Install all desktop apps as Flatpaks
+      <li>Build Flatpaks in Fedora
+      <li>Good support for "pet containers" in the desktop
+      <li>Support package layering for OS extensions in GNOME Software
+      <li>Support rebases and rollbacks of the OS in GNOME Software
+      <li>Support automatic updates of apps in GNOME Software
+      <li>Support kernel modules in rpm-ostree
+    </ul>
+    <p>Several of these tasks are underway for Fedora 29. Take a look at our
+    <a href="https://pagure.io/teamsilverblue/issues">issue tracker</a>
+    to find out more about their status and other tasks.</p>
+
+    <h3>Infrastructure</h3>
+
+    <p>Like most projects, Team Silverblue has a <a href="https://teamsilverblue.org">website</a>
+    (the one you're on now, in fact). It serves as the central point for information around Silverblue.
+    Over time, we hope to make this a go-to place for learning more about Linux and containers.</p>
+
+    <p>The Silverblue <a href="https://silverblue.fedoraproject.org/download">iso image</a> and OSTree repository are built and hosted in the Fedora build
+    infrastructure.</p>
+
+    <p>There are several ways to get in touch with Silverblue team members:</p>
+    <ul>
+      <li>The Silverblue <a href="https://discussion.fedoraproject.org/c/silverblue">community</a> is an excellent
+          place to ask a question or discuss Silverblue topics
+      <li>Alternatively, there is a &num;silverblue IRC channel on freenode
+      <li>If you want to report an issue or make a suggestion, you can use the <a href="https://pagure.io/teamsilverblue/issues">issue tracker</a>
+    </ul>
+
 </article>
+
+
 {{end}}

--- a/pages/stories/index.html
+++ b/pages/stories/index.html
@@ -3,6 +3,20 @@
 
 {{define "body"}}
 <article>
+  <h2>Congratulations, Flatpak!</h2>
+    <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2018-08-20">August 20, 2018</time></p>
+
+    <p>Flatpak has reached a major milestone today, with its 1.0 release.</p>
+
+    <a href="https://www.flatpak.org/press/2018-08-20-flatpak-1.0/"><image src="https://www.flatpak.org/img/delivery_truck.png"/></a>
+
+    <p>We in Team Silverblue are all excited and happy to use <a href="https://www.flatpak.org/press/2018-08-20-flatpak-1.0/">Flatpak 1.0</a> as the solid
+    foundation for application deployment and execution in Fedora Silverblue.</p>
+
+    <p>Keep it coming! ️💓📦💓📦</p>
+</article>
+
+<article>
   <h2>Welcome to the party, Fedora CoreOS!</h2>
     <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2018-06-21">June 21, 2018</time></p>
 


### PR DESCRIPTION
Fatpak 1.0 is no longer news. This commit moves the
"Flatpak 1.0" post to the story archive and brings back
the informative overview article, with some edits and
minor updates.

This should address Garrett's suggestions from twitter.