### PR TITLE
Added this silverblue-logo.sh ascii art

### DIFF
--- a/public/silverblue-logo.sh
+++ b/public/silverblue-logo.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+clear
+cat << X0
+[38;5;153m              __assssssssssssssssssssssssssssssss[38;5;123miiiiiiiiiii[38;5;4m,
+           [38;5;117m.%nSSonnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnonooonon[38;5;4ml;
+[38;5;12m          <oooonoooooooooooooooooooooooooooooooooooooooooo[38;5;4ml|;
+         [38;5;12mvoooooooo2ooo2ooooo2ooooo2ooooo2ooooo2ooo2oo2o2o[38;5;4mli|;
+        [38;5;12muooo2o2o2ooo2ooo2o2ooo2o2ooo2o2ooo2o2ooo2ooo2ooo[38;5;4ml||i;
+       [38;5;12mvnoo2oooooo2oo2o2oooo2oooo2o2oooo2oooo2o2oo2oooo[38;5;4ml|i|i;
+      [38;5;12m-oooooo2o2o2oo2ooooo2oo2o2oooooo2oo2o2oooooooo2o[38;5;4mli|i||;
+      [38;5;12mooo2o2ooooooo2ooo2o2oo2oooo2o2o2oo2oooo2o2o2o2o[38;5;4ml||i||i;
+     [38;5;12m-2ooooo2o2ooXoooo2oooo2ooo2Xoooooo2ooo2ooooXnoo[38;5;4ml|i||i|i;
+     [38;5;12mvoo2o2oooom[38;5;253mQQQ[38;5;12mmnooo2o2oo2m[38;5;253mQQQ[38;5;12mmo2o2oo2oooq[38;5;253mQQQ[38;5;12mmp[38;5;4mi|i||i|i|;
+     [38;5;12m2ooooo2o2[38;5;253mQQQQQQ[38;5;12mpoo2ooooom[38;5;253mWQQQQ[38;5;12mmooooooo2q[38;5;253mQQQQQQ[38;5;4m>||i|i|||;
+    [38;5;12m:oo2o2ooo[38;5;253mXQQ@VQQQn[38;5;12mooo2o22[38;5;253mQQWVWWQX[38;5;12moo2o2oo[38;5;253mmQQVSQQe[38;5;4mii||i|i|;
+    [38;5;12m-ooooo2o2[38;5;253mdQQ[38;5;12mnod[38;5;253mQQ[38;5;12moo2oooo[38;5;253mXQQ[38;5;12mknd[38;5;253mWQE[38;5;12mnooooo2[38;5;253mQQ#[38;5;12mn[38;5;4mi[38;5;253mQWk[38;5;4mi||i|||i;
+    [38;5;12m-o2o2oooo[38;5;253mdQQ[38;5;12mmo[38;5;253mQQQ[38;5;12moooo2o2[38;5;253mXWQ[38;5;12mmXm[38;5;253mQQk[38;5;12mnoo2o2o[38;5;253mQWQ[38;5;4mza[38;5;253mQQk[38;5;4m||i||ii|;
+    [38;5;12m-oooo2o2o[38;5;253mSQQQQQQD[38;5;12mno2oooon[38;5;253mSQQQWQW[38;5;12mnnoooooo[38;5;253mmQQQQQQ[38;5;4m(i||i|i||;
+    [38;5;12m-2o2oooooo[38;5;253mdWQQQB[38;5;12mnoooo2o2oX[38;5;253mWWQQWC[38;5;12mooo2o2o[38;5;253mQQQQQQWC[38;5;4m||i|i|||i;
+    [38;5;12m-oooo2o2ooo[38;5;253moQQ#[38;5;12mooo2o2oooonn[38;5;253mSQWo[38;5;12mooo2ooo[38;5;253mQWQD*[38;5;4mYY|||i|||i|i|;
+    [38;5;12m-o2o2oooo2o[38;5;253moWQ#[38;5;12mooooooo2o2oo[38;5;253mmQWo[38;5;12moo2ooo[38;5;253moQWQD[38;5;4m|||||i||ii||i|;
+    [38;5;12m-2oooo2o2oo[38;5;253moQQ#[38;5;12moo2o2o2ooooo[38;5;253mmQWo[38;5;12mo2ooo[38;5;253mQQQD[38;5;4m||i||i|i|i|||i|i;
+    [38;5;12m-oo2o2oooo2[38;5;253moWQ#[38;5;12moooooooo2o2o[38;5;253mmQWo[38;5;12moooo[38;5;253mQWQD[38;5;4m||i|i|i||i||i|i||;
+    [38;5;12m-o2oooo2o2o[38;5;253moQQ#[38;5;12mo2o2o2o2oooo[38;5;253mmQQo[38;5;12mo2o[38;5;253mQQQD[38;5;4m||i||i||i||i|i||i|;
+    [38;5;12m-oooo2ooooo[38;5;253moQQ#[38;5;12mooooooooo2o2[38;5;253mmQWn[38;5;12moo[38;5;253mQWQD[38;5;4m||i||i||i|i||i||i|i;
+    [38;5;12m-o2o2oo2o2o[38;5;253moQW#[38;5;12moo2o2o2o2ooo[38;5;253mmQWo[38;5;12mo[38;5;253mQWQD[38;5;4m||i||i|i|i||i|i|i||i;
+    [38;5;12m-ooooo2oooo[38;5;253m2WQ#[38;5;12mo2oooooooo2o[38;5;253mmQWoQWQD[38;5;4m||i||i||i||i||i|||i|i;
+    [38;5;12m-o2o2ooo2o2[38;5;253moWQ#[38;5;12mooo2o2o2o2oo[38;5;253mmQQQWQD[38;5;4m||i||i|i[38;5;253myQQw%[38;5;4m|i||i|i||;
+    [38;5;12m-ooooo2oooo[38;5;253moQQ#[38;5;12mo2oooooooooo[38;5;253mmQQWQD[38;5;4m||i||i|i[38;5;253mQQWWQm%[38;5;4m|i|i||i|;
+    [38;5;12m-o2o2ooo2o2[38;5;253moWQ#[38;5;12mooo2o2o2o2o2[38;5;253mmQQQQwwwwwwww[38;5;253myQQDHWQk[38;5;4m||i||i|i;
+    [38;5;12m-ooooo2oooo[38;5;253moQQ#[38;5;12mo2oooooo2ooo[38;5;253mQQQQQWQWQQWQQQQB[38;5;4m||[38;5;253mWQm[38;5;4m|i||i|i|;
+    [38;5;12m-oo2o2oo2o2[38;5;253moWQ#[38;5;12mooo2o2o2ooo[38;5;253mQQWQWQWQWQWQWQQQQ[38;5;4m%i[38;5;253mQWE[38;5;4m|||i|i||;
+    [38;5;12m-o2oooo2ooo[38;5;253moQQ#[38;5;12mo2oooo2ooo[38;5;253mQQQD[38;5;4m|||||||||||[38;5;253m3WQQWWQC[38;5;4m|i|i|||i;
+    [38;5;12m-ooo2o2oo2o[38;5;253m2QQ#[38;5;12mooo2o2ooo[38;5;253mQQQD[38;5;4m|||i|i|i|i|i|[38;5;253m9QQWQE[38;5;4m||||i|i|i;
+    [38;5;12m-oo2ooooooo[38;5;253moQW#[38;5;12mo2oooooo[38;5;253mQQQE[38;5;4m|||i||i||i|i||i[38;5;253m?TT1[38;5;4m|||i||i||i;
+    [38;5;12m-oooo2o2o2o[38;5;253m2QW#[38;5;12mooo2o2o[38;5;253mQQQE[38;5;4m|||i||i||i|||i|i|i|i||i||i||i|;
+    [38;5;12m-oo2ooooooo[38;5;253moWQ#[38;5;12m2o2ooo[38;5;253mQQQE[38;5;4m||i|i|i|i|i|i|i||i|i||i||i|i|i|;
+    [38;5;12m-oo2o2o2o2o[38;5;253m2QQm[38;5;12mooooo[38;5;253mQQQE[38;5;4m||i|||i|||i||i||i||i||i||i|i|||i;
+    [38;5;12m-oooooooooo[38;5;253moQWm[38;5;12moo2o[38;5;253mQQQE[38;5;4m||i||i|i|i|i|i||i|i|i|i|i|i|||ii|;
+    [38;5;12m-oo2o2o2o2o[38;5;253moWQm[38;5;12mooo[38;5;253mQQQE[38;5;4m||i||i|i|||i|||i|i||i|||i||i|i|i||;
+    [38;5;12m-ooooooooo2[38;5;253moQQ#[38;5;12moo[38;5;253mQQQE[38;5;4m||i||i||i|i|i|i|i||i||i|i||i|||i||i;
+    [38;5;12m-oo2o2o2o2o[38;5;253moQQ#[38;5;12mo[38;5;253mQQQE[38;5;4m||i||i|i||i||i||i||i|i|i||i|i|i|i|i|;
+    [38;5;12m-oooooooooo[38;5;253moWQmQQQE[38;5;4m||||i||i||i||i||i||i||[38;5;253miwmmw[38;5;4m||i||i|||i;
+    [38;5;12m-oo2o2o2o2o[38;5;253m2WQQQQE[38;5;4m|||i|i|i||i|i|i|i||i|ii[38;5;253mmQQQQm[38;5;4mi||i||i|i;
+    [38;5;12m-ooooooo2oo[38;5;253moQQQQB[38;5;4maaaaaaaaaaaaaaaaaaaaaaaq[38;5;253mQQ@SQQz[38;5;4mi||i|i||;
+    [38;5;12m-ooo2o2ooo2[38;5;253moWQQQQWQWQQQQWQQQQQWQQWQQQQQWQWW[38;5;4m||[38;5;253mQWm[38;5;4m|i|i||i|;
+    [38;5;12m:oo2oooo2[38;5;253moooQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ[38;5;4m||[38;5;253mQWD[38;5;4m|i||i||i;
+    [38;5;12m-oooo2o2[38;5;253moo2nY?Y?Y?Y?Y?Y?Y?Y?Y?Y?Y?Y?Y?Y?9QWQmQQC[38;5;4m||i|i|i|:
+    [38;5;12m:o2o2oo[38;5;253mooon[38;5;4m||||||i|||i|||||||||||i|||||ii[38;5;253mSQWQQD[38;5;4m|i|i|||i|:
+    [38;5;12m-ooooo[38;5;253m2o2n[38;5;4miii|ii||i|i||i|ii|ii|i|i|i|i||||[38;5;253mYHHY[38;5;4m|||i||i|i|
+    [38;5;12m:o2o2[38;5;253mooon[38;5;4mi|||i||i||i||i|i||i||i|i|||i|i|i|||||||i||i|i|;
+    [38;5;12m:2oo[38;5;253moo2n[38;5;4mi|i|i||i|i|i|i||i|i||i|||i|i||i|i|i||||i||i||i|
+    [38;5;12m:2o[38;5;253mo2on[38;5;4mi|i|i|i|i||i|||i|i|||i|i|i|i|i||i||i|i|i||i|i||;
+    [38;5;12m:2[38;5;253mooon[38;5;4mi|i|||i||i|i||i|i||i|i||i||i|||i||i||i|i|i|i||i>
+    [38;5;253m:oo2n[38;5;4mi|i||i|i|i|||i||i||i||i|i||i||i|i|i|i||i|||i||i|
+    [38;5;253m:2on[38;5;4m|i|i|i|i|||i|i|i|i|i|i|i||i|i|i|i||i||i|i|i||i|>
+    [38;5;253m:on[38;5;4mii|i|||i||i|i||i|||i|||i||i||i||i||i||i||i||i|i+
+    [38;5;253m:n[38;5;4mi||i||i|i|i|i||i||i|i|i|i|i||i||i||i|i||i|i|i|+,
+    -++++++++++++++++++|++++++++++|+++++|++++|+++~,
+    ___ _ _             _    _
+   / __(_) |_ _____ _ _| |__| |_  _ ___
+   \__ \ | \ V / -_) '_| '_ \ | || / -_)
+   |___/_|_|\_/\___|_| |_.__/_|\_,_\___|
+[0m
+X0

--- a/public/silverblue-white-logo.sh
+++ b/public/silverblue-white-logo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/zsh
+
+cat << X0
+[0m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                    [0;10m[1m_[0;10mgg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1ma[0;10mg[1m,[0;10m[8m            [0;10m
+[8m                  [0;10mq[1myQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m                 [0;10m[1mjQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m               .[0;10m[1mjQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m               [0;10mj[1mQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              =[0;10m[1mmQQQQQQWQQQQQQQQWQQQQQQQQQWQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10mj[1mQQQQQD^[0;10m[8m [0;10m7[1mQWQQQQ![0;10m[8m [0;10m-[1m4WQQQQ@^[0;10m[8m [0;10m][1mSQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQ[0;10m [1m.a[0;10m[8m [0;10m[1m]WQQQE[0;10m[8m [0;10mqp[8m [0;10m[1mSQQQQ[0;10m _[1ma[0;10m [1m)WQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQ[0;10m [1m)W[0;10m j[1mQQQQL[0;10m[8m [0;10m[1m4f[0;10m[8m [0;10m[1mdQQQQ[0;10m ][1mW[0;10m ][1mQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1mjQQQQQc[0;10m[8m  .[0;10m[1mjQQQQm[0;10m,[8m X[0;10m[1m_QQQQ@ [0;10m[8m v [0;10m[1m,@fjQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQc[0;10m[8m [0;10m[1mjQQQQQQm[0;10m [1m_mQQQ@^[0;10m[8m:[0;10m[1ma[0;10mg[1mwWQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1mjQQQQQQk[0;10m[8m [0;10m[1mmQQQQQQQ[0;10m j[1mQQQ@^[0;10m[8m=[0;10m[1mjQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mdQQQQQQQ[0;10m j[1mQQW^[0;10m[8m+[0;10m[1mjQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1mjQQQQQQk[0;10m[8m [0;10m[1mmQQQQQQQ[0;10m j[1mQW^[0;10m[8m [0;10m[1mjQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mdQQQQQQQ[0;10m j[1mW^[0;10m[8m [0;10m[1mjQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1mjQQQQQQk[0;10m[8m [0;10m[1mmQQQQQQQ[0;10m [1m^[0;10m[8m [0;10m [1mjQQQQP?4QQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mdQQQQQQQ[0;10m [8m =[0;10m[1mjWWWWf[0;10m[8m   [0;10m[1m]QQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mmQQQQQQ@^[0;10m[8m        [0;10m][1mQ[0;10m )[1mQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1mjQQQQQQk[0;10m[8m [0;10m[1mdQQQQQ@^[0;10m[8m [0;10m[1maaaaaaa,[0;10m-[1m?[0;10m j[1mQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mmQQQQ@^[0;10m[8m [0;10m[1mjQWQWQWQm,[0;10m[8m [0;10m[1m_mQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mdQQQ@^[0;10m[8m [0;10m[1mjQQQQQQQQQQmQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mmQQ@^[0;10m[8m [0;10m[1mjQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mdQ@^[0;10m[8m [0;10m[1mjQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1mm@^[0;10m[8m [0;10m[1mjQQQQQQQQQQQQQQQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m[1md^[0;10m[8m [0;10m[1mjQQQQQQQQQQQQQQBQQQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m [0;10m^[8m [0;10m[1mjQQQQQQQQQQQQQ@^[0;10m[8m [0;10m)[1mSWQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m  [0;10m][1m??????????????^[0;10m_[1ma[0;10m ][1mQQQQQ([0;10m[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQk[0;10m[8m                  [0;10m][1mW[0;10m ][1mQQQQQ[0;10mL[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQWQmL[0;10m[8m   [0;10m[1mjWQQQQ[0;10m[[8m            [0;10m
+[8m              [0;10m[1m]QQQQQQQQWWQWWWWWWWWWWWWQQwaaQWQQQ@[0;10m[8m             [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQQQQQQWQQQQQQ[[0;10m[8m             [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ@[0;10m^[8m             [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQW^[0;10m[8m              [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ@^[0;10m[8m               [0;10m
+[8m              [0;10m[1m]QQQQQQQQQQQQQQQQQQQQQQQQQQQWD^[0;10m[8m                 [0;10m
+[8m              [0;10m-[1m~[0;10m^[1m~[0;10m^[1m~[0;10m^[1m~[0;10m^^^^^^^^^^^^^^^^^^[8m                   [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m              =[0;10m[1m_, [0;10m[8m [0;10m[1m.[0;10m[8m [0;10m,[8m [0;10m _,[8m [0;10m[1m.[0;10m[8m [0;10m[1m _[0;10mw, _[1m_, [0;10m[8mX[0;10m_ [1m_,[0;10m[8mn[0;10m_,[8m  [0;10m [1m.[0;10m[8m  [0;10m,  _[1m__[0;10m[8m             [0;10m
+[8m              [0;10m[1m]~* [0;10m[8m=[0;10m[1m{[0;10m[8m [0;10m[1m[[0;10m[8m [0;10m )[1m[[0;10m[8m [0;10m[1m%[0;10m) [1mf^^ ]^^[ [0;10mj[1m}^[0;10mp jf[8m  [0;10m [1ml [0;10m[8m [0;10mjf[1m ]^^[0;10m[8m=            [0;10m
+[8m              [0;10m][1ms, [0;10m[8m [0;10m[1mi[0;10m[8m.[0;10m[1m[[0;10m[8m  [0;10m[1m i[0;10m_[1m[[0;10m[8mQ[0;10m [1mL,[0;10m[8m [0;10m [1m),[0;10mq[1m( [0;10mj[1mc[0;10mg[1m' [0;10mjf[8m  [0;10m [1ml [0;10m[8m [0;10m]f [1m][0;10mg/[8m             [0;10m
+[8m               [0;10m-[1m{[0;10m, [1mv[0;10m[8m [0;10m[1m[[0;10m[8m  [0;10m[1m ][0;10mj[1m^[0;10m[8mQ[0;10m [1mr[0;10m^[8m [0;10m [1m)^1[0;10m[8m [0;10m jF![1m[ [0;10mjf[8m  [0;10m [1ml [0;10m[8m [0;10mjf [1m][0;10m"'[8m             [0;10m
+[8m              [0;10mj[1m,j[0;10m^ [1mi[0;10m[8m [0;10m[1mL[0;10mw[1m,[0;10m -[1m2[0;10m[8m[0;10m)  [1mc_, )[0;10m^[1m), [0;10mjgg[1mr [0;10mj[1mc_[0;10m  [1m], j[0;10m^ [1m][0;10mww,[8m            [0;10m
+[8m              |[0;10m[1m^ [0;10m[8m [0;10m ^[8m [0;10m![1m~^[0;10m[8m [0;10m ^[8m  [0;10m [1m~~^[0;10m -[8m- [0;10m^- [1m^~[0;10m[8m  [0;10m [1m~~^[0;10m[8m [0;10m [1m^^[0;10m[8m~[0;10m  ^[1m~~[0;10m[8m             [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[8m                                                              [0;10m
+[0m
+X0

--- a/public/silverblue_logo_aa.zsh
+++ b/public/silverblue_logo_aa.zsh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms of the Do What You Want
+# To Public License, Version 0.01, as published by Steven Snow. See
+# this document for more details.
+clear
+cat << X0
+     [0m[38;5;12m(QXXXXXXXXXXXXXXXX/[38;5;24m7[0m
+  [0m[38;5;12m(XXXXXXXXXXXXXXXXXXX/[38;5;24mOO[0m
+ [38;5;12m(XXXXXXXXXXXXXXXXXXX/[38;5;24mOOO[0m
+[38;5;12m(XXXXXXXXXXXXXXXX[38;5;255m(QQo[38;5;24mOOOO[0m
+[38;5;12mPXXXXXXXXXXXXXXX[38;5;255mX[38;5;12mXX/[38;5;255mO)[38;5;24mOOO[0m
+[38;5;12mPXXXXXXXXXXXXXXX[38;5;255mXX/O)[38;5;24mOOOO[0m
+[38;5;12mPXXXXXX[38;5;255mXX[38;5;12mXXXXXX[38;5;255mXX/O[38;5;24mOOOOOO[0m
+[38;5;12mPXXXXX[38;5;255mX[38;5;12mXX[38;5;255mX[38;5;12mXXXX[38;5;255mXX/O[38;5;24mOOOOOOO[0m
+[38;5;12mPXXXXX[38;5;255mX[38;5;12mXX[38;5;255mX[38;5;12mXXX[38;5;255mXX/O[38;5;24mOOOOOOOO[0m
+[38;5;12mPXXXXXX[38;5;255mXX[38;5;12mXXX[38;5;255mXX/O[38;5;24mOOOOOOOOO[0m
+[38;5;12mPXXXXXX[38;5;255mXX[38;5;12mXX[38;5;255mXX/O[38;5;24mOOOOOOOOOO[0m
+[38;5;12mPX[38;5;255mXX[38;5;12mXXX[38;5;255mXX[38;5;12mX[38;5;255mXX/O[38;5;24mOOO[38;5;255mOO[38;5;24mOOOOOO[0m
+[38;5;12mP[38;5;255mX[38;5;12mXX[38;5;255mX[38;5;12mXX[38;5;255mXXXX/OOOOO[38;5;24mOO[38;5;255mO[38;5;24mOOOOO[0m
+[38;5;12mP[38;5;255mX[38;5;12mXX[38;5;255mX[38;5;12mXX[38;5;255mXXX/OOOOOO[38;5;24mOO[38;5;255mO[38;5;24mOOOOO[0m
+[38;5;12mPX[38;5;255mXX[38;5;12mXXX[38;5;255mXX/O[38;5;24mOOOOOO[38;5;255mOO[38;5;24mOOOOOO[0m
+[38;5;12mPX[38;5;255mXX[38;5;12mXX[38;5;255mXX/O[38;5;24mOOOOOOOOOOOOOOO[0m
+[38;5;12mPX[38;5;255mXX[38;5;12mX[38;5;255mXX/O[38;5;24mOOOOOOOOOOOOOOOO[0m
+[38;5;12mPX[38;5;255mXXXX/O[38;5;24mOOOOOOOOO[38;5;255mOO[38;5;24mOOOOOO[0m
+[38;5;12mPX[38;5;255mXXX/OOOOOOOOOOO[38;5;24mOO[38;5;255mO[38;5;24mOOOO)[0m
+[38;5;12mPX[38;5;255mXX/OOOOOOOOOOOO[38;5;24mOO[38;5;255mO[38;5;24mOOO)[0m
+[38;5;12mPXX/[38;5;24mOOOOOOOOOOOOO[38;5;255mOO[38;5;24mOOOj[0m
+[38;5;12mPX/[38;5;24mOOOOOOOOOOOOOOOOOO)[0m
+[38;5;12mL/[38;5;24mOOOOOOOOOOOOOOOOO)[0m
+[38;5;12m  [38;5;12m___ _ _             [38;5;24m_    _          [38;5;12m
+ / __(@) |_ _____ _ _[38;5;24m| |__| |_  _ ___ [38;5;12m
+ \__ \ | \ V / -_) '_[38;5;24m| '_ \ | || / -_)[38;5;12m
+ |___/_|_|\_/\___|_| [38;5;24m|_.__/_|\_,_\___|[0m
+X0
+exit 0


### PR DESCRIPTION
Added a small shell script to create an ascii art logo for your Silverblue terminal experience. I use zsh, and it works with it, and I have tested it on bash as well where it works. The image was created by using Gimp to convert a half scaled silverblue-logo.svg image, then manually fixing the escape sequences.