### PR TITLE
Don't link to a specific rawhide compose

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -28,7 +28,7 @@ since rpm-ostree expects this setup.</p>
 
 <p>Help us make Silverblue better by testing the <b>Rawhide</b> builds of Silverblue that
 will eventually become Fedora 30.</p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-Rawhide-20181201.n.0.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 2.0GB Silverblue image (Fedora Rawhide)</a></p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Silverblue/x86_64/iso/'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 2.1GB Silverblue image (Fedora Rawhide)</a></p>
 
 <h1>Get Fedora Media Writer</h1>
 


### PR DESCRIPTION
These are dates, and disappear before too long :(

Just link to the directory, and trust users to pick the
iso from there.