### PR TITLE
Removed Noto Colour Emoji from body

### DIFF
--- a/public/teamsilverblue-style.css
+++ b/public/teamsilverblue-style.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css?family=Overpass|Source+Code+Pro|Source+Sans+Pro");
 body {
-  font-family: "Source Sans Pro", "Noto Color Emoji", Sans-Serif;
+  font-family: "Source Sans Pro", Sans-Serif;
   font-size: 12pt;
   line-height: 1.5em;
   max-width: 62em;


### PR DESCRIPTION
The way this font is currently being used is making the page somewhat unreadable.

It adds a space between each word that just seems really jarring for no good reason.

I think these changes are caused by blocking remote fonts. If the first one fails, it falls back to some really bad default. It may be nicer to perhaps choose something a little more sensible like say Roboto,Helvetica,Arial,sans-serif.

I   d o n ' t   r e a l l y   m i n d   m e m e   f o n t s   b u t   i t   i s n ' t   t h e   e a s i e s t   t o   r e a d.