### PR TITLE
Changed year to 2019 for Fedora 30 announcement

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -5,7 +5,7 @@
 
 <article>
   <h2>Fedora 30 has been released today!</h2>
-  <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2019-04-30">April 30, 2018</time></p>
+  <p class="author">by Matthias Clasen and Sanja Bonic &ndash; <time datetime="2019-04-30">April 30, 2019</time></p>
 
   <p>Exactly 6 months after the Fedora 29 release, here is Fedora 30!
 And Silverblue is part of it. Please


### PR DESCRIPTION
The byline had the wrong year for the date of 2018. I changed it to 2019.