### PR TITLE
Added Dark Mode CSS

### DIFF
--- a/public/teamsilverblue-style.css
+++ b/public/teamsilverblue-style.css
@@ -225,4 +225,23 @@ blockquote:after {
     height: auto;
     margin: 16px; } }
 
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #444;
+    color: #e4e4e4;
+  }
+
+  a {
+    color: #e39777;
+  }
+
+  img {
+    filter: grayscale(30%);
+  }
+
+  #copyright {
+    color: #e4e4e4;
+  }
+}
+
 /*# sourceMappingURL=teamsilverblue-style.css.map */


### PR DESCRIPTION
Hello,

I was just reading hacker news and saw this rather cool new feature that is being built into browsers. In this case the support for dark mode for browsers that request it.

![image](https://user-images.githubusercontent.com/8430304/66723907-fcd4b380-ee16-11e9-83d1-bc392c21be55.png)

I was hoping to use this as one of my hacktoberfest submissions this year, so please let me know if there are things so i can fix it.

EDIT: FYI you won't see it unless your browser is asking for dark mode sites. Otherwise you would normally get the bright white website. To enable dark mode requests on Firefox just apply the following setting.

url > about:config > accept the risk > right click > new > integer 

key is ui.systemUsesDarkTheme
value is 1

EDIT2: FYI this isn't some random CSS that is only supported on Firefox. It has support in Chrome, Safari etc.. https://caniuse.com/#search=prefers-color-scheme

Kind regards,
Krish
