### PR TITLE
Add: Fedora 31 general announcement link

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -7,7 +7,7 @@
   <h2>Fedora 31 is now available!</h2>
   <p class="author">by Team Silverblue &ndash; <time datetime="2019-11-01">November 1, 2019</time></p>
 
-  <p>Team Silverblue is proud to announce the release of Silverblue 31. Please <a href="https://silverblue.fedoraproject.org/download">download</a> it and let us know what you think about this release!</p>
+  <p>We are proud to announce the release of Silverblue 31. Please <a href="https://silverblue.fedoraproject.org/download">download</a> it and let us know what you think about this release!</p>
 
     <img class="blog-image" alt="Silverblue logo" src="/public/silverblue-logo.svg">
 
@@ -18,6 +18,8 @@
       <li>CgroupsV2 becoming our default control groups
     </ul>
   </p>
+
+  <p> Please, also take a look at the Fedora 31 release <a href="https://fedoramagazine.org/announcing-fedora-31/">announcement</a>. This includes an overall summary of improvements common to all of our Fedora flavours</p>
 
   <p> As always, before installing or upgrading your system to Silverblue 31, make sure to check the latest known issues:
     <ul>


### PR DESCRIPTION
@miabbott @dustymabe: Add the Fedora 31 announcement link. Background: https://discussion.fedoraproject.org/t/silverblue-site-indicates-31-is-still-beta/10648/7?u=returntrip