### PR TITLE
Fix download media writer links

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -61,8 +61,8 @@ these instructions
 
 <p>Fedora Media Writer is supported on Linux, OS X and Windows:
 <a class="button" href="https://flathub.org/repo/appstream/org.fedoraproject.MediaWriter.flatpakref">Fedora Media Writer for <b>Linux</b></a>
-<a class="button" href="https://getfedora.org/fmw/FedoraMediaWriter-osx-4.1.4.dmg">Fedora Media Writer for <b>OS X</b></a>
-<a class="button" href="https://getfedora.org/fmw/FedoraMediaWriter-win32-4.1.4.exe">Fedora Media Writer for <b>Windows</b></a>
+<a class="button" href="https://getfedora.org/fmw/FedoraMediaWriter-osx-latest.dmg">Fedora Media Writer for <b>OS X</b></a>
+<a class="button" href="https://getfedora.org/fmw/FedoraMediaWriter-win32-latest.exe">Fedora Media Writer for <b>Windows</b></a>
 </p>
 
 <details class="conditions">


### PR DESCRIPTION
I don't know if is the right solution, but in order to fix #84 issue, I found that the download media writers links on [getfedora.org](https://getfedora.org/en/workstation/download) sites points to [GH Fedora QT releases](https://github.com/FedoraQt/MediaWriter/releases).
Also I found that the [fedora-web pagure project](https://pagure.io/fedora-web/websites/blob/master/f/sites/getfedora.org/site/workstation/download/index.html#_67) has an smart solution to get the latest version of them in order to avoid to use a fixed version, but I don't know if that kind of solution could handle on SB website.

Is there any better way to get the latest tag version of them on the SB website?

Any help will be very appreciate!