### PR TITLE
Fixed missing error handling on invalid input

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -32,8 +32,10 @@ func templateHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			errorHandler(w, r, http.StatusNotFound)
-			return
+		} else {
+			errorHandler(w, r, http.StatusBadRequest)
 		}
+		return
 	}
 
 	if info.IsDir() {


### PR DESCRIPTION
This change fixes the missing error handling on invalid URL (e.g. `/.%00./`)