### PR TITLE
Change year in footer

### DIFF
--- a/templates/structure.html
+++ b/templates/structure.html
@@ -42,7 +42,7 @@
       <a href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">Privacy Policy</a>
     </nav>
     <p id="copyright">
-      &copy; 2019 Fedora Silverblue.<br>A Fedora initiative.
+      &copy; 2021 Fedora Silverblue.<br>A Fedora initiative.
     </p>
   </footer>
 </body>


### PR DESCRIPTION
The year in footer in the Fedora Silverblue site was 2019, I updated it to 2021