### PR TITLE
Change hardcoded x86_64 mirror link

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -6,7 +6,7 @@
 <h1>Download a Silverblue image</h1>
 
 <p>Silverblue images for Fedora 34 are provided by the Fedora Project.</p>
-<p><a class="button" href='https://mirror.karneval.cz/pub/linux/fedora/linux/releases/34/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-34-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 34)</a></p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/34/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-34-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 34)</a></p>
 <p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/34/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-34-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 34)</a></p>
 <p><a class="button" href='https://download.fedoraproject.org/pub/fedora-secondary/releases/34/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-34-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 34)</a></p>
 


### PR DESCRIPTION
The F34 x86_64 download link was hardcoded to the mirror.karneval.cz mirror. I changed it to the download.fedoraproject.org site.