### PR TITLE
Migrate from freenode to liberachat

### DIFF
--- a/pages/contribute/index.html
+++ b/pages/contribute/index.html
@@ -30,7 +30,7 @@ We accept pull requests and do not require a CLA.</p>
 <p>We've canceled IRC meetings in favor of discussiong things timezone-independently on the <a href="https://discussion.fedoraproject.org/c/desktop/silverblue">forums</a>.</p>
 
 <p>Outside of the forums, you can always come by and chat about Silverblue
-in the &num;silverblue IRC channel on freenode.</p>
+in the &num;silverblue IRC channel on Libera.Chat.</p>
 
 <p>You can best discuss Silverblue in our
 <a href="https://discussion.fedoraproject.org/c/desktop/silverblue">community</a>.

--- a/pages/index.html
+++ b/pages/index.html
@@ -254,7 +254,7 @@ And Silverblue is part of it. Please
     <ul>
       <li>The Silverblue <a href="https://discussion.fedoraproject.org/c/desktop/silverblue">community</a> is an excellent
           place to ask a question or discuss Silverblue topics
-      <li>Alternatively, there is a &num;silverblue IRC channel on freenode
+      <li>Alternatively, there is a &num;silverblue IRC channel on Libera.Chat
       <li>If you want to report an issue or make a suggestion, you can use the <a href="https://pagure.io/teamsilverblue/issues">issue tracker</a>
     </ul>
 

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -37,7 +37,7 @@
     <nav>
       <a href="https://twitter.com/teamsilverblue"><svg class="icon"><use href="/public/svg-sprites.svg#twitter" /></svg>Twitter</a>
       <a href="https://github.com/fedora-silverblue"><svg class="icon"><use href="/public/svg-sprites.svg#github" /></svg>Github</a>
-      <a href="https://webchat.freenode.net/#silverblue"><svg class="icon"><use href="/public/svg-sprites.svg#hash" /></svg>IRC</a>
+      <a href="https://web.libera.chat/#silverblue"><svg class="icon"><use href="/public/svg-sprites.svg#hash" /></svg>IRC</a>
       <a href="https://discussion.fedoraproject.org/c/desktop/silverblue"><svg class="icon"><use href="/public/svg-sprites.svg#comments" /></svg>Community</a>
       <a href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">Privacy Policy</a>
     </nav>


### PR DESCRIPTION
https://fedoramagazine.org/irc-announcement/

Update the Contribute page, site footer and an old article to replace Freenode with Libera.Chat.

Thanks in advance for reviewing!