### PR TITLE
Fedora 36 release anouncement and maintenance work

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -5,10 +5,10 @@
 <article>
 <h1>Download a Silverblue image</h1>
 
-<p>Silverblue images for Fedora 35 are provided by the Fedora Project.</p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/35/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-35-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 35)</a></p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/35/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-35-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 35)</a></p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora-secondary/releases/35/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-35-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 35)</a></p>
+<p>Silverblue images for Fedora 36 are provided by the Fedora Project.</p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-36-1.5.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 36)</a></p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-36-1.5.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 36)</a></p>
+<!--p><a class="button" href='https://download.fedoraproject.org/pub/fedora-secondary/releases/35/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-35-1.2.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 35)</a></p>-->
 
 <p>Fedora provides the Media Writer as a convenient way to create bootable USB drives.</p>
 <p>You will need
@@ -26,23 +26,23 @@ and follow the prompts to write the image to the USB Drive.</p>
 advisable to keep the default partitioning setup that the Installer suggests,
 since rpm-ostree expects this setup.</p>
 <p>You can verify your download with
-<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/35/Silverblue/x86_64/iso/Fedora-Silverblue-35-1.2-x86_64-CHECKSUM">x86_64</a> or
-<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/35/Silverblue/aarch64/iso/Fedora-Silverblue-35-1.2-aarch64-CHECKSUM">aarch64</a> or
-<a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/35/Silverblue/ppc64le/iso/Fedora-Silverblue-35-1.2-ppc64le-CHECKSUM">ppc64le</a>
+<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/x86_64/iso/Fedora-Silverblue-36-1.5-x86_64-CHECKSUM">x86_64</a> or
+<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/aarch64/iso/Fedora-Silverblue-36-1.5-aarch64-CHECKSUM">aarch64</a> or
+<!--a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/35/Silverblue/ppc64le/iso/Fedora-Silverblue-35-1.2-ppc64le-CHECKSUM">ppc64le</a>-->
 checksum file
 </a> by following
-<a href="https://docs.fedoraproject.org/en-US/fedora/f35/install-guide/install/Preparing_for_Installation/#sect-verifying-images">these instructions<a>.</p>
+<a href="https://docs.fedoraproject.org/en-US/fedora/f36/install-guide/install/Preparing_for_Installation/#sect-verifying-images">these instructions<a>.</p>
 
-<!-- Uncomment when Silverblue 36 is available: <h1>Try Fedora 36 composes</h1>
+<!-- Uncomment when Silverblue 37 is available: <h1>Try Fedora 37 composes</h1>
   <p>Help us make Silverblue better by testing the <b>early</b> builds of Silverblue.</p>
-https://dl.fedoraproject.org/pub/fedora/linux/development/36/Silverblue/x86_64/iso/
+https://dl.fedoraproject.org/pub/fedora/linux/development/37/Silverblue/x86_64/iso/
   <p><a class="button" >
   <svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>Coming Soon</a></p>-->
 
 <h1>Try the latest</h1>
 
 <p>Help us make Silverblue better by testing the <b>Rawhide</b> builds of Silverblue that
-will eventually become Fedora 36.</p>
+will eventually become Fedora 37.</p>
 
 <p><a class="button" href='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Silverblue/x86_64/iso/'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 2.5GB Silverblue image (Fedora Rawhide)</a></p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,6 +4,37 @@
 {{define "body"}}
 
 <article>
+  <h2>Welcome to Fedora Silverblue 36!</h2>
+  <p class="author">by Team Silverblue &ndash; <time datetime="2022-05-10">May 10, 2022</time></p>
+
+  <p>We are proud to announce the release of Fedora Silverblue 36. Please <a href="https://silverblue.fedoraproject.org/download">try it</a> and tell us what you think!</p>
+
+  <img class="blog-image" alt="Silverblue logo" src="/public/silverblue-logo.svg">
+
+  <p>This release includes some exciting improvements, such as:
+    <ul>
+      <li>GNOME 42 with improved dark mode, more apps ported to GTK 4 and new improved screenshot app
+      <li>GNU Toolchain update (gcc 12, glibc 2.35)
+      <li>New installs will have /var on its own subvolume by default
+      <li>OpenSSL upgraded to version 3.0
+      <li>GDM sessions will run on Wayland by default when using NVIDIA driver
+      <li>Podman upgraded to 4.0 with improved performance and rewrited network stack
+    </ul>
+  </p>
+
+  <p>You can find more details about all the new and exciting improvements in Fedora 36 at the following links:
+    <ul>
+      <li>The Fedora 36 official <a href="https://fedoramagazine.org/announcing-fedora-36/">announcement</a>. This includes an overall summary of improvements common to all of our Fedora flavours.
+    </ul>
+  </p>
+
+  <p>As always, before installing or upgrading your system to Silverblue 36, make sure to check the latest known <a href="https://ask.fedoraproject.org/tags/c/common-issues/141/none/f36/l/latest">issues</a>.</p>
+
+  <p>Enjoy Fedora Silverblue and happy rebasing to everyone!</p>
+
+</article>
+
+<article>
   <h2>Welcome to Fedora Silverblue 35!</h2>
   <p class="author">by Team Silverblue &ndash; <time datetime="2021-11-02">November 02, 2021</time></p>
 

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -42,7 +42,7 @@
       <a href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">Privacy Policy</a>
     </nav>
     <p id="copyright">
-      &copy; 2021 Fedora Silverblue.<br>A Fedora initiative.
+      &copy; 2022 Fedora Silverblue.<br>A Fedora initiative.
     </p>
   </footer>
 </body>


### PR DESCRIPTION
Hello

Created an Fedora 36 release announcement, changed download links to point Fedora 36, updated year in footer.

Commented out download button for ppc64le because I cannot find any working download link for that. If it exists, I would like to ask for help.