### PR TITLE
Add About page

### DIFF
--- a/pages/about/index.html
+++ b/pages/about/index.html
@@ -1,0 +1,33 @@
+<!-- See structure.html for the template names used here and their position in the layout. -->
+{{define "title"}}Team Silverblue &mdash; About{{end}}
+
+{{define "body"}}
+
+<article>
+<h1>What is Silverblue?</h1>
+
+<p>
+  Silverblue is a variant of Fedora Workstation.
+  It looks, feels and behaves like a regular desktop operating system, and the experience is similar to what you find with using a standard Fedora Workstation.
+</p>
+
+<p>
+  However, unlike other operating systems, Silverblue is immutable.
+  This means that every installation is identical to every other installation of the same version.
+  The operating system that is on disk is exactly the same from one machine to the next, and it never changes as it is used.
+</p>
+
+<p>
+  Silverblue&#39;s immutable design is intended to make it more stable, less prone to bugs, and easier to test and develop.
+  Finally, Silverblue&#39;s immutable design also makes it an excellent platform for containerized applications as well as container-based software development.
+  In each case, applications (apps) and containers are kept separate from the host system, improving stability and reliability.
+</p>
+
+<p>
+  Silverblue&#39;s core technologies have some other helpful features.
+  OS updates are fast and there’s no waiting around for them to install: just reboot as normal to start using the next version.
+  With Silverblue, it is also possible to roll back to the previous version of the operating system, if something goes wrong.
+</p>
+</article>
+
+{{end}}

--- a/src/main.go
+++ b/src/main.go
@@ -24,6 +24,8 @@ func templateHandler(w http.ResponseWriter, r *http.Request) {
 		content = "../pages/download/index.html"
 	case "/elsewhere":
 		content ="../pages/elsewhere/index.html"
+	case "/about":
+		content ="../pages/about/index.html"                
 	default:
 		content = "../pages/" + r.URL.Path + ".html"
 	}

--- a/templates/structure.html
+++ b/templates/structure.html
@@ -20,6 +20,7 @@
   <header>
     <a class="logo" href="/"><img alt="Silverblue logo" src="/public/silverblue-logo.svg"></a>
     <nav>
+        <a href="/about">About</a>
         <a href="https://discussion.fedoraproject.org/c/desktop/silverblue"></svg>Community</a>
         <a href="/contribute"></svg>Contribute</a>
         <a href="https://docs.fedoraproject.org/en-US/fedora-silverblue/">Documentation</a>


### PR DESCRIPTION
The current site doesn't really explain what Silverblue is, at least not in an easy-to-find place and in an easy quotable "elevator pitch".

I've added an About page to help people understand what the project is.