### PR TITLE
Maintenance work after f37 release

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -5,10 +5,10 @@
 <article>
 <h1>Download a Silverblue image</h1>
 
-<p>Silverblue images for Fedora 36 are provided by the Fedora Project.</p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-36-1.5.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 36)</a></p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-36-1.5.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 36)</a></p>
-<p><a class="button" href='https://dl.fedoraproject.org/pub/fedora-secondary/releases/36/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-36-1.5.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 36)</a></p>
+<p>Silverblue images for Fedora 37 are provided by the Fedora Project.</p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 37)</a></p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 37)</a></p>
+<p><a class="button" href='https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 37)</a></p>
 
 <p>Fedora provides the Media Writer as a convenient way to create bootable USB drives.</p>
 <p>You will need</p>
@@ -26,22 +26,16 @@ and follow the prompts to write the image to the USB Drive.</p>
 advisable to keep the default partitioning setup that the Installer suggests,
 since rpm-ostree expects this setup.</p>
 <p>You can verify your download with
-<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/x86_64/iso/Fedora-Silverblue-36-1.5-x86_64-CHECKSUM">x86_64</a> or
-<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/36/Silverblue/aarch64/iso/Fedora-Silverblue-36-1.5-aarch64-CHECKSUM">aarch64</a> or
-<a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/36/Silverblue/ppc64le/iso/Fedora-Silverblue-36-1.5-ppc64le-CHECKSUM">ppc64le</a>
+<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/x86_64/iso/Fedora-Silverblue-37-1.7-x86_64-CHECKSUM">x86_64</a> or
+<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/aarch64/iso/Fedora-Silverblue-37-1.7-aarch64-CHECKSUM">aarch64</a> or
+<a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/37/Silverblue/ppc64le/iso/Fedora-Silverblue-37-1.7-ppc64le-CHECKSUM">ppc64le</a>
 checksum file by following
-<a href="https://docs.fedoraproject.org/en-US/fedora/f36/install-guide/install/Preparing_for_Installation/#sect-verifying-images">these instructions</a>.</p>
-
-<!-- Uncomment when Silverblue 37 is available: <h1>Try Fedora 37 composes</h1>
-  <p>Help us make Silverblue better by testing the <b>early</b> builds of Silverblue.</p>
-https://dl.fedoraproject.org/pub/fedora/linux/development/37/Silverblue/x86_64/iso/
-  <p><a class="button" >
-  <svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>Coming Soon</a></p>-->
+<a href="https://docs.fedoraproject.org/en-US/fedora/f37/install-guide/install/Preparing_for_Installation/#sect-verifying-images">these instructions</a>.</p>
 
 <h1>Try the latest</h1>
 
 <p>Help us make Silverblue better by testing the <b>Rawhide</b> builds of Silverblue that
-will eventually become Fedora 37.</p>
+will eventually become Fedora 38.</p>
 
 <p><a class="button" href='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Silverblue/x86_64/iso/'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>64-bit 2.5GB Silverblue image (Fedora Rawhide)</a></p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,6 +4,37 @@
 {{define "body"}}
 
 <article>
+  <h2>Welcome to Fedora Silverblue 37!</h2>
+  <p class="author">by Team Silverblue &ndash; <time datetime="2022-11-15">Nov 15, 2022</time></p>
+
+  <p>We are proud to announce the release of Fedora Silverblue 37. Please <a href="https://silverblue.fedoraproject.org/download">try it</a> and tell us what you think!</p>
+
+  <img class="blog-image" alt="Silverblue logo" src="/public/silverblue-logo.svg">
+
+  <p>This release includes some exciting improvements, such as:</p>
+  <ul>
+    <li>GNOME 43 with new Device Security tab
+    <li>GNU Toolchain update (binutils 2.38, glibc 2.36)
+    <li>/sysroot is now read-only on Silverblue systems
+  </ul>
+
+  <p>You can find more details about all the new and exciting improvements in Fedora 37 at the following links:</p>
+  <ul>
+    <li>The Fedora 37 official <a href="https://fedoramagazine.org/announcing-fedora-37/">announcement</a>. This includes an overall summary of improvements common to all of our Fedora flavours.
+  </ul>
+
+  <p>
+    As always, before installing or upgrading your system to Silverblue 37, make sure to check the latest known <a href="https://ask.fedoraproject.org/tags/c/common-issues/141/none/f37/l/latest">issues</a>.
+    See also the <a href="https://github.com/fedora-silverblue/issue-tracker/issues">Silverblue issue tracker</a> that tracks issues specific to Fedora Silverblue.
+  </p>
+
+  <p>If you have issues with updating or upgrading your Silverblue instalation, please see <a href="https://fedoramagazine.org/manual-action-required-to-update-fedora-silverblue-kinoite-and-iot-version-36/">this article</a> and try the described workaround.</p>
+
+  <p>Enjoy Fedora Silverblue and happy rebasing to everyone!</p>
+
+</article>
+
+<article>
   <h2>Welcome to Fedora Silverblue 36!</h2>
   <p class="author">by Team Silverblue &ndash; <time datetime="2022-05-10">May 10, 2022</time></p>
 


### PR DESCRIPTION
As usual, added F37 release announcement, and changed download links to point F37.

I found that there is no f37 compose for ppc64le on https://dl.fedoraproject.org/pub/fedora-secondary/releases/ so, I don't know if the download link will be ok when it will appear.