### PR TITLE
Update download links for Fedora 38

### DIFF
--- a/pages/download/index.html
+++ b/pages/download/index.html
@@ -5,10 +5,10 @@
 <article>
 <h1>Download a Silverblue image</h1>
 
-<p>Silverblue images for Fedora 37 are provided by the Fedora Project.</p>
-<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 37)</a></p>
+<p>Silverblue images for Fedora 38 are provided by the Fedora Project.</p>
+<p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/38/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-38-1.6.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>x86_64 2.6GB Silverblue image (Fedora 38)</a></p>
 <p><a class="button" href='https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>aarch64 2.0GB Silverblue image (Fedora 37)</a></p>
-<p><a class="button" href='https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-37-1.7.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 37)</a></p>
+<p><a class="button" href='https://dl.fedoraproject.org/pub/fedora-secondary/releases/38/Silverblue/ppc64le/iso/Fedora-Silverblue-ostree-ppc64le-38-1.6.iso'><svg class="icon"><use href="/public/svg-sprites.svg#download" /></svg>ppc64le 2.1GB Silverblue image (Fedora 38)</a></p>
 
 <p>Fedora provides the Media Writer as a convenient way to create bootable USB drives.</p>
 <p>You will need</p>
@@ -26,9 +26,9 @@ and follow the prompts to write the image to the USB Drive.</p>
 advisable to keep the default partitioning setup that the Installer suggests,
 since rpm-ostree expects this setup.</p>
 <p>You can verify your download with
-<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/x86_64/iso/Fedora-Silverblue-37-1.7-x86_64-CHECKSUM">x86_64</a> or
+<a href="https://download.fedoraproject.org/pub/fedora/linux/releases/38/Silverblue/x86_64/iso/Fedora-Silverblue-38-1.6-x86_64-CHECKSUM">x86_64</a> or
 <a href="https://download.fedoraproject.org/pub/fedora/linux/releases/37/Silverblue/aarch64/iso/Fedora-Silverblue-37-1.7-aarch64-CHECKSUM">aarch64</a> or
-<a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/37/Silverblue/ppc64le/iso/Fedora-Silverblue-37-1.7-ppc64le-CHECKSUM">ppc64le</a>
+<a href="https://download.fedoraproject.org/pub/fedora-secondary/releases/38/Silverblue/ppc64le/iso/Fedora-Silverblue-38-1.6-ppc64le-CHECKSUM">ppc64le</a>
 checksum file by following
 <a href="https://docs.fedoraproject.org/en-US/fedora/latest/preparing-boot-media/#sect-verifying-images">these instructions</a>.</p>
 


### PR DESCRIPTION
There are no aarch64 38 ISOs for now.

See: https://github.com/fedora-silverblue/issue-tracker/issues/453